### PR TITLE
Add comprehensive financial statement footnote disclosure templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ultimate 401(k) Understanding Information Database
 
-**Version 2.1.0 | Updated November 2025 | 36,000+ Lines of Documentation**
+**Version 2.2.0 | Updated November 2025 | 37,000+ Lines of Documentation**
 
 The most comprehensive resource for understanding every detail of 401(k) retirement plans and **401(k) audits** - covering both limited scope and full scope engagements, MEPs, PEPs, and everything in between.
 
@@ -60,6 +60,7 @@ The most comprehensive resource for understanding every detail of 401(k) retirem
 - [Engagement Letter Templates](docs/401k-engagement-letters.md) - Limited scope, full scope, and first-year engagement letters
 - [Management Representation Letters](docs/401k-management-representations.md) - Comprehensive rep letter templates
 - [Fraud Risk Assessment](docs/401k-fraud-risk-assessment.md) - Fraud risk evaluation templates and procedures
+- [Footnote Disclosure Templates](docs/401k-footnote-disclosures.md) - Complete financial statement note templates
 
 ### Part 4D: Specialized Plan Audits
 - [MEP and PEP Audits](docs/401k-mep-pep-audits.md) - Multiple Employer Plans and Pooled Employer Plans audit guide
@@ -191,12 +192,12 @@ You'll find detailed, actionable information organized for easy reference.
 | Audit Procedures | 9 guides | ~6,500 | Planning through reporting |
 | Limited Scope Resources | 7 templates | ~5,100 | Programs, checklists, templates |
 | Full Scope Resources | 1 program | ~730 | Complete full scope audit program |
-| Audit Tools & Templates | 4 templates | ~2,740 | Calculations, letters, fraud assessment |
+| Audit Tools & Templates | 5 templates | ~3,500 | Calculations, letters, fraud, footnotes |
 | Specialized Audits | 1 guide | ~800 | MEP/PEP audit procedures |
 | Reference Materials | 4 guides | ~4,130 | Glossary, flowcharts, case studies, QC |
 | Regulatory & Compliance | 4 guides | ~3,400 | DOL, IRS, Form 5500, SECURE 2.0 |
 | Special Topics | 3 guides | ~1,700 | Cybersecurity, external resources, state-specific |
-| **Total** | **47+ documents** | **~36,000+** | **THE ULTIMATE RESOURCE** |
+| **Total** | **48+ documents** | **~37,000+** | **THE ULTIMATE RESOURCE** |
 
 ### New in Version 2.0.0
 

--- a/docs/401k-footnote-disclosures.md
+++ b/docs/401k-footnote-disclosures.md
@@ -1,0 +1,818 @@
+# Financial Statement Note Disclosure Templates
+
+## Overview
+
+This document provides comprehensive footnote disclosure templates for 401(k) plan financial statements. Templates are organized by category with fill-in-the-blank placeholders indicated by [BRACKETS].
+
+---
+
+## Table of Contents
+
+1. [Standard Required Disclosures](#part-1-standard-required-disclosures)
+2. [Investment Disclosures](#part-2-investment-disclosures)
+3. [Transfers & Plan Changes](#part-3-transfers--plan-changes)
+4. [Participant Activity](#part-4-participant-activity)
+5. [Compliance & Regulatory](#part-5-compliance--regulatory)
+6. [Special Situations](#part-6-special-situations)
+7. [SECURE 2.0 Disclosures](#part-7-secure-20-disclosures)
+8. [Form 5500 Reconciliation](#part-8-form-5500-reconciliation)
+
+---
+
+## Part 1: Standard Required Disclosures
+
+### Note 1: Description of Plan
+
+#### General Plan Description
+
+The [PLAN NAME] (the "Plan") is a defined contribution plan covering all eligible employees of [COMPANY NAME] (the "Company" or "Plan Sponsor") who have attained age [21] and completed [1 year/1,000 hours] of service. The Plan is subject to the provisions of the Employee Retirement Income Security Act of 1974, as amended ("ERISA"). Participants should refer to the Plan document and Summary Plan Description for a more complete description of the Plan's provisions.
+
+#### Contributions
+
+**Employee Contributions**
+
+Participants may elect to defer up to [XX]% of their eligible compensation on a pre-tax basis, subject to Internal Revenue Code ("IRC") limitations. For the plan year ended [DATE], the maximum elective deferral was $[23,500] ($[31,000] for participants age 50 and older). Participants may also elect to make Roth (after-tax) contributions subject to the same limitations.
+
+**Employer Matching Contributions**
+
+The Company provides a matching contribution equal to [100]% of the first [3]% of compensation deferred, plus [50]% of the next [2]% of compensation deferred, for a maximum match of [4]% of eligible compensation.
+
+*Alternative - Safe Harbor Match:*
+The Plan is designed as a Safe Harbor 401(k) plan. The Company provides a Safe Harbor matching contribution equal to 100% of the first 3% of compensation deferred, plus 50% of the next 2% of compensation deferred, for a maximum match of 4% of eligible compensation.
+
+*Alternative - Safe Harbor Non-Elective:*
+The Plan is designed as a Safe Harbor 401(k) plan. The Company provides a Safe Harbor non-elective contribution equal to 3% of eligible compensation to all eligible participants regardless of whether they make elective deferrals.
+
+**Employer Profit Sharing Contributions**
+
+The Company may make discretionary profit sharing contributions as determined annually by the Board of Directors. For the plan year ended [DATE], the Company contributed $[AMOUNT] in profit sharing contributions.
+
+*Alternative - No Profit Sharing:*
+The Plan does not provide for employer profit sharing contributions.
+
+**Rollover Contributions**
+
+The Plan accepts rollover contributions from other qualified plans, 403(b) plans, governmental 457(b) plans, and Individual Retirement Accounts ("IRAs").
+
+#### Participant Accounts
+
+Each participant's account is credited with the participant's elective deferrals, employer contributions, Plan earnings, and is charged with an allocation of administrative expenses. Allocations are based on participant account balances or eligible compensation, as defined in the Plan document. The benefit to which a participant is entitled is the benefit that can be provided from the participant's vested account balance.
+
+#### Vesting
+
+**Employee Contributions**
+Participants are immediately vested in their elective deferrals and rollover contributions, plus actual earnings thereon.
+
+**Employer Contributions**
+
+*Graded Vesting Schedule:*
+Employer matching and profit sharing contributions vest according to the following schedule:
+
+| Years of Service | Vested Percentage |
+|-----------------|-------------------|
+| Less than 1 year | 0% |
+| 1 year | 20% |
+| 2 years | 40% |
+| 3 years | 60% |
+| 4 years | 80% |
+| 5 years | 100% |
+
+*Cliff Vesting Schedule:*
+Employer matching and profit sharing contributions vest 100% after [3] years of service.
+
+*Immediate Vesting:*
+Participants are immediately vested in all employer contributions.
+
+*Safe Harbor Vesting:*
+Participants are immediately vested in all Safe Harbor contributions. Non-Safe Harbor employer contributions vest according to [the schedule described above].
+
+#### Forfeitures
+
+Forfeited non-vested accounts are used to [reduce future employer contributions / pay Plan administrative expenses / allocate to remaining participants]. At [YEAR END DATE], forfeited non-vested accounts totaled $[AMOUNT]. During the plan year ended [DATE], forfeitures of $[AMOUNT] were used to [reduce employer contributions / pay administrative expenses].
+
+#### Payment of Benefits
+
+Upon termination of employment, death, disability, or attainment of age 59½, participants may elect to receive their vested account balance in a lump sum payment, installment payments, or as a direct rollover to another qualified plan or IRA. Hardship withdrawals and in-service withdrawals at age 59½ are also permitted as described in the Plan document.
+
+#### Participant Loans
+
+The Plan permits participants to borrow from their account balances up to the lesser of $50,000 (reduced by the highest outstanding loan balance during the preceding 12 months) or 50% of the participant's vested account balance. Loans bear interest at [prime rate plus 1%] and must be repaid within [5] years, or up to [15/20/25] years for the purchase of a primary residence. Principal and interest are repaid through payroll deductions.
+
+*Alternative - No Loans:*
+The Plan does not permit participant loans.
+
+#### Administrative Expenses
+
+Certain administrative expenses of maintaining the Plan are paid by the Plan, while other expenses are paid by the Company. Expenses paid by the Plan are allocated to participant accounts [pro rata based on account balances / per capita / as specifically incurred].
+
+---
+
+### Note 2: Summary of Significant Accounting Policies
+
+#### Basis of Accounting
+
+The accompanying financial statements have been prepared on the accrual basis of accounting in accordance with accounting principles generally accepted in the United States of America ("GAAP").
+
+#### Use of Estimates
+
+The preparation of financial statements in conformity with GAAP requires management to make estimates and assumptions that affect the reported amounts of assets and liabilities and disclosure of contingent assets and liabilities at the date of the financial statements and the reported amounts of additions and deductions during the reporting period. Actual results could differ from those estimates.
+
+#### Investment Valuation and Income Recognition
+
+Investments are reported at fair value. Fair value is the price that would be received to sell an asset or paid to transfer a liability in an orderly transaction between market participants at the measurement date. See Note [X] for discussion of fair value measurements.
+
+Purchases and sales of securities are recorded on a trade-date basis. Interest income is recorded on the accrual basis. Dividends are recorded on the ex-dividend date. Net appreciation (depreciation) includes the Plan's gains and losses on investments bought and sold as well as held during the year.
+
+#### Fully Benefit-Responsive Investment Contracts
+
+The Plan holds investments in [stable value fund / guaranteed investment contracts] that are fully benefit-responsive. These investments are reported at fair value in the Statement of Net Assets Available for Benefits with an adjustment to contract value in a separate line item. Contract value represents contributions plus accumulated interest. Participants may ordinarily direct the withdrawal or transfer of all or a portion of their investment at contract value. See Note [X] for additional information.
+
+*Alternative - If no stable value:*
+The Plan does not hold any investments in fully benefit-responsive investment contracts.
+
+#### Notes Receivable from Participants
+
+Notes receivable from participants represent participant loans that are recorded at their unpaid principal balance plus any accrued but unpaid interest. Interest income is recorded on the accrual basis. Delinquent loans are reclassified as distributions based on the terms of the Plan document. No allowance for credit losses has been recorded as of [DATE]. If a participant ceases to make loan repayments and the Plan administrator deems the participant loan to be a distribution, the participant loan balance is reduced and a benefit payment is recorded.
+
+#### Payment of Benefits
+
+Benefits are recorded when paid.
+
+#### Recently Issued Accounting Pronouncements
+
+*Include if applicable:*
+In [MONTH YEAR], the Financial Accounting Standards Board ("FASB") issued Accounting Standards Update ("ASU") [NUMBER], [TITLE]. [Describe the standard and its impact on the Plan's financial statements, or state that it is not expected to have a material impact.]
+
+---
+
+### Note 3: Tax Status
+
+The Plan obtained its latest determination letter on [DATE], in which the Internal Revenue Service ("IRS") stated that the Plan, as then designed, was in compliance with applicable requirements of the IRC. The Plan has been amended since receiving the determination letter; however, the Plan administrator and the Plan's tax counsel believe that the Plan is currently designed and being operated in compliance with the applicable requirements of the IRC and, therefore, believe that the Plan is qualified and the related trust is tax-exempt.
+
+GAAP requires Plan management to evaluate tax positions taken by the Plan and recognize a tax liability if the Plan has taken an uncertain position that more likely than not would not be sustained upon examination by the IRS. The Plan administrator has analyzed the tax positions taken by the Plan, and has concluded that as of [DATE], there are no uncertain positions taken or expected to be taken that would require recognition of a liability or disclosure in the financial statements.
+
+The Plan is subject to routine audits by taxing jurisdictions; however, there are currently no audits for any tax periods in progress.
+
+---
+
+### Note 4: Fair Value Measurements
+
+FASB Accounting Standards Codification ("ASC") 820, *Fair Value Measurement*, establishes a framework for measuring fair value. That framework provides a fair value hierarchy that prioritizes the inputs to valuation techniques used to measure fair value. The hierarchy gives the highest priority to unadjusted quoted prices in active markets for identical assets or liabilities (Level 1) and the lowest priority to unobservable inputs (Level 3).
+
+The three levels of the fair value hierarchy under ASC 820 are described as follows:
+
+**Level 1** - Inputs to the valuation methodology are unadjusted quoted prices for identical assets or liabilities in active markets that the Plan has the ability to access.
+
+**Level 2** - Inputs to the valuation methodology include:
+- Quoted prices for similar assets or liabilities in active markets
+- Quoted prices for identical or similar assets or liabilities in inactive markets
+- Inputs other than quoted prices that are observable for the asset or liability
+- Inputs that are derived principally from or corroborated by observable market data by correlation or other means
+
+**Level 3** - Inputs to the valuation methodology are unobservable and significant to the fair value measurement.
+
+The asset's or liability's fair value measurement level within the fair value hierarchy is based on the lowest level of any input that is significant to the fair value measurement. Valuation techniques used need to maximize the use of observable inputs and minimize the use of unobservable inputs.
+
+Following is a description of the valuation methodologies used for assets measured at fair value:
+
+**Mutual Funds**: Valued at the daily closing price as reported by the fund. These funds are required to publish their daily net asset value ("NAV") and to transact at that price. Mutual funds held by the Plan are actively traded and are classified within Level 1 of the fair value hierarchy.
+
+**Common/Collective Trust Funds**: Valued at the NAV of units held by the Plan at year-end as provided by the fund administrator. The NAV is based on the value of the underlying assets owned by the fund, minus its liabilities, and then divided by the number of units outstanding. Common/collective trust funds are measured at fair value using the NAV per share practical expedient and are not classified in the fair value hierarchy.
+
+**Employer Securities**: Valued at the closing price reported on the active market on which the individual securities are traded. These securities are classified within Level 1 of the fair value hierarchy.
+
+*Alternative for privately held employer securities:*
+**Employer Securities**: The Plan holds stock of [COMPANY NAME], a privately held company. These securities are valued based on an independent appraisal performed annually as of [DATE]. The valuation methodology considers factors such as earnings, book value, and market comparables. These securities are classified within Level 3 of the fair value hierarchy.
+
+**Self-Directed Brokerage Accounts**: Investments in self-directed brokerage accounts consist primarily of mutual funds, stocks, bonds, and money market funds. These investments are valued at quoted market prices and are classified within Level 1 of the fair value hierarchy.
+
+#### Fair Value Hierarchy Table
+
+The following table sets forth by level, within the fair value hierarchy, the Plan's assets at fair value as of [DATE]:
+
+| | Level 1 | Level 2 | Level 3 | Total |
+|---|---------|---------|---------|-------|
+| Mutual funds: | | | | |
+| Equity funds | $X | $— | $— | $X |
+| Fixed income funds | X | — | — | X |
+| Money market funds | X | — | — | X |
+| Employer securities | X | — | — | X |
+| **Total assets in fair value hierarchy** | **$X** | **$—** | **$—** | **$X** |
+| Investments measured at NAV* | | | | X |
+| **Total investments at fair value** | | | | **$X** |
+
+*Investments measured at NAV as a practical expedient have not been classified in the fair value hierarchy.
+
+#### Investments Measured Using Net Asset Value Per Share
+
+The following table summarizes investments for which fair value is measured using the NAV per share practical expedient as of [DATE]:
+
+| Investment | Fair Value | Unfunded Commitments | Redemption Frequency | Redemption Notice Period |
+|------------|-----------|---------------------|---------------------|------------------------|
+| Common/collective trust - stable value | $X | N/A | Daily | None |
+| Common/collective trust - equity index | X | N/A | Daily | None |
+| Common/collective trust - target date | X | N/A | Daily | None |
+| **Total** | **$X** | | | |
+
+---
+
+### Note 5: Party-in-Interest / Related Party Transactions
+
+Certain Plan investments are managed by [TRUSTEE/RECORDKEEPER NAME], which is the trustee and recordkeeper of the Plan. These transactions qualify as party-in-interest transactions; however, they are exempt from the prohibited transaction rules under ERISA.
+
+The Plan holds [NUMBER] shares of common stock of [COMPANY NAME], the Plan Sponsor, valued at $[AMOUNT] at [DATE]. Purchases, sales, and dividends related to employer securities qualify as party-in-interest transactions but are exempt from the prohibited transaction rules.
+
+Loans to participants are also party-in-interest transactions but are exempt from the prohibited transaction rules.
+
+At [DATE], the Plan held $[AMOUNT] in notes receivable from participants, which bear interest at rates ranging from [X]% to [Y]%.
+
+Certain administrative expenses of the Plan are paid by the Company on behalf of the Plan. Such amounts are excluded from these financial statements.
+
+---
+
+### Note 6: Plan Termination
+
+Although it has not expressed any intent to do so, the Company has the right under the Plan to discontinue its contributions at any time and to terminate the Plan subject to the provisions of ERISA. In the event of Plan termination, participants will become 100% vested in their accounts.
+
+---
+
+### Note 7: Risks and Uncertainties
+
+The Plan provides for various investment options in mutual funds, common/collective trust funds, and employer securities. Investment securities are exposed to various risks, such as interest rate, market, and credit risks. Due to the level of risk associated with certain investment securities and the level of uncertainty related to changes in the value of investment securities, it is at least reasonably possible that changes in risks in the near term would materially affect the amounts reported in the Statement of Net Assets Available for Benefits and the Statement of Changes in Net Assets Available for Benefits.
+
+*Additional disclosure for employer securities:*
+Plan assets include [COMPANY NAME] common stock, representing approximately [X]% of total Plan assets at [DATE]. A significant decline in the market value of [COMPANY NAME] common stock would significantly affect the net assets available for benefits.
+
+*Additional disclosure for concentrated investments:*
+Plan assets include investments in [FUND NAME], representing approximately [X]% of total Plan assets at [DATE]. A significant decline in the market value of this investment would significantly affect the net assets available for benefits.
+
+---
+
+## Part 2: Investment Disclosures
+
+### Note: Investments
+
+The following presents investments that represent 5% or more of the Plan's net assets at [DATE]:
+
+| Investment | Fair Value |
+|------------|-----------|
+| [FUND NAME 1] | $X |
+| [FUND NAME 2] | X |
+| [FUND NAME 3] | X |
+| Employer common stock | X |
+
+During the plan year ended [DATE], the Plan's investments (including gains and losses on investments bought and sold, as well as held during the year) appreciated (depreciated) in fair value as follows:
+
+| Investment Type | Net Appreciation (Depreciation) |
+|----------------|-------------------------------|
+| Mutual funds | $X |
+| Common/collective trust funds | X |
+| Employer securities | X |
+| **Total** | **$X** |
+
+---
+
+### Note: Fully Benefit-Responsive Investment Contracts (Stable Value)
+
+The Plan holds a fully benefit-responsive investment contract with [INSURANCE COMPANY/STABLE VALUE FUND NAME]. This investment is presented at fair value in the Statement of Net Assets Available for Benefits with an adjustment to contract value in a separate line item.
+
+As described in ASC 962, *Plan Accounting – Defined Contribution Pension Plans*, investment contracts held by a defined contribution plan are required to be reported at fair value. However, contract value is the relevant measurement attribute for that portion of the net assets available for benefits of a defined contribution plan attributable to fully benefit-responsive investment contracts because contract value is the amount participants would receive if they were to initiate permitted transactions under the terms of the Plan.
+
+The stable value fund invests primarily in investment contracts issued by insurance companies and other financial institutions, fixed income securities, and money market funds. Participants may ordinarily direct the withdrawal or transfer of all or a portion of their investment at contract value.
+
+As of [DATE], the fair value and contract value of the fully benefit-responsive investment contracts were as follows:
+
+| | [CURRENT YEAR] | [PRIOR YEAR] |
+|---|---------------|--------------|
+| Fair value | $X | $X |
+| Adjustment from fair value to contract value | X | X |
+| **Contract value** | **$X** | **$X** |
+
+The average yield and crediting interest rate for the stable value fund were as follows:
+
+| | [CURRENT YEAR] | [PRIOR YEAR] |
+|---|---------------|--------------|
+| Average yield | X.XX% | X.XX% |
+| Crediting interest rate | X.XX% | X.XX% |
+
+The crediting interest rate is based on an agreed-upon formula with the issuer, but may not be less than zero. Such rate is reviewed on a quarterly basis for resetting.
+
+Certain events limit the ability of the Plan to transact at contract value with the contract issuers. Such events include:
+- Amendments to the Plan document
+- Complete or partial Plan termination or merger with another plan
+- Employer bankruptcy or reorganization
+- Changes to competing investment options
+- Failure to qualify under Section 401(a) of the IRC
+
+The Plan administrator does not believe that any events that would limit the Plan's ability to transact at contract value with participants are probable of occurring.
+
+---
+
+### Note: Self-Directed Brokerage Accounts
+
+The Plan offers participants the option to invest a portion of their account balance in a self-directed brokerage account ("SDBA") through [BROKERAGE PROVIDER]. Participants may invest in a wide range of investments including mutual funds, exchange-traded funds, individual stocks, and bonds, subject to certain restrictions as outlined in the Plan document.
+
+As of [DATE], the SDBA held investments with a fair value of $[AMOUNT], representing approximately [X]% of total Plan assets. The investments held in the SDBA are participant-directed, and the Plan has no fiduciary responsibility for the selection of investments within the SDBA.
+
+---
+
+### Note: Employer Securities
+
+The Plan allows participants to invest in common stock of [COMPANY NAME], the Plan Sponsor. Employer securities are participant-directed and subject to the diversification requirements under ERISA Section 204(j).
+
+As of [DATE], the Plan held [NUMBER] shares of [COMPANY NAME] common stock with a fair value of $[AMOUNT], representing approximately [X]% of total Plan assets.
+
+Dividends on employer securities are [reinvested in additional shares of company stock / paid in cash to participants / allocated based on participant elections].
+
+---
+
+### Note: Alternative Investments
+
+*For plans with hedge funds, private equity, real estate, etc.:*
+
+The Plan holds investments in alternative investment funds as part of a diversified investment strategy. These investments may include:
+
+| Investment | Fair Value | Strategy |
+|------------|-----------|----------|
+| [FUND NAME] | $X | [Private equity / Hedge fund / Real estate] |
+
+Due to the nature of these investments, values may be estimated using the most recent available information, which may differ from values that would be determined if a ready market existed. The Plan's ability to redeem these investments may be subject to lock-up periods and other restrictions as described in the fund offering documents.
+
+---
+
+## Part 3: Transfers & Plan Changes
+
+### Note: Transfers from Other Plans
+
+During the plan year ended [DATE], the Plan received transfers of $[AMOUNT] from [TRANSFERRING PLAN NAME] as a result of [describe reason - merger, acquisition, etc.].
+
+*Detailed version:*
+On [DATE], [COMPANY NAME] acquired [ACQUIRED COMPANY NAME]. As a result of the acquisition, the assets and liabilities of [ACQUIRED COMPANY PLAN NAME] were merged into the Plan effective [DATE]. The transfer included the following:
+
+| | Amount |
+|---|--------|
+| Participant account balances | $X |
+| Participant loans | X |
+| Forfeitures | X |
+| **Total transferred in** | **$X** |
+
+The transferred assets included [NUMBER] participant accounts. Participants from the merged plan retained their vesting service credit and account balances were invested according to their elections or the Plan's default investment option.
+
+---
+
+### Note: Transfers to Other Plans
+
+During the plan year ended [DATE], the Plan transferred $[AMOUNT] to [RECEIVING PLAN NAME] as a result of [describe reason - spinoff, divestiture, etc.].
+
+*Detailed version:*
+On [DATE], [COMPANY NAME] completed the sale of its [DIVISION NAME] division to [ACQUIRING COMPANY NAME]. As a result, assets of $[AMOUNT] representing [NUMBER] participant accounts were transferred to [NEW PLAN NAME] effective [DATE].
+
+| | Amount |
+|---|--------|
+| Participant account balances | $X |
+| Participant loans | X |
+| **Total transferred out** | **$X** |
+
+---
+
+### Note: Transfer to Pooled Employer Plan (PEP)
+
+Effective [DATE], [COMPANY NAME] elected to participate in the [PEP NAME] Pooled Employer Plan. As a result, all Plan assets and participant accounts were transferred to the PEP.
+
+| | Amount |
+|---|--------|
+| Participant account balances transferred | $X |
+| Participant loans transferred | X |
+| Forfeitures transferred | X |
+| **Total transferred to PEP** | **$X** |
+
+The transfer included [NUMBER] participant accounts. Participant vesting service and account balances were preserved in the transfer. The Plan was terminated effective [DATE] following the completion of the transfer.
+
+*Alternative - Partial transfer to PEP:*
+Effective [DATE], [COMPANY NAME] elected to participate in the [PEP NAME] Pooled Employer Plan for a portion of its workforce. Assets of $[AMOUNT] representing [NUMBER] participant accounts from [DIVISION/LOCATION] were transferred to the PEP, while the remaining Plan assets continue to be maintained in this Plan.
+
+---
+
+### Note: Transfer from Pooled Employer Plan (PEP)
+
+Effective [DATE], [COMPANY NAME] withdrew from the [PEP NAME] Pooled Employer Plan and established this Plan to hold participant accounts. The following assets were transferred from the PEP:
+
+| | Amount |
+|---|--------|
+| Participant account balances | $X |
+| Participant loans | X |
+| **Total transferred from PEP** | **$X** |
+
+The transfer included [NUMBER] participant accounts. Participant vesting service and account balances were preserved in the transfer.
+
+---
+
+### Note: Transfer to Multiple Employer Plan (MEP)
+
+Effective [DATE], [COMPANY NAME] elected to participate in the [MEP NAME] Multiple Employer Plan. As a result, all Plan assets and participant accounts were transferred to the MEP.
+
+| | Amount |
+|---|--------|
+| Participant account balances transferred | $X |
+| Participant loans transferred | X |
+| Forfeitures transferred | X |
+| **Total transferred to MEP** | **$X** |
+
+---
+
+### Note: Transfer from Multiple Employer Plan (MEP)
+
+Effective [DATE], [COMPANY NAME] withdrew from the [MEP NAME] Multiple Employer Plan and established this Plan. The following assets were transferred from the MEP:
+
+| | Amount |
+|---|--------|
+| Participant account balances | $X |
+| Participant loans | X |
+| **Total transferred from MEP** | **$X** |
+
+---
+
+### Note: Plan Merger
+
+Effective [DATE], the [MERGED PLAN NAME] was merged into the Plan. The merger was completed to [reduce administrative costs / consolidate plans following acquisition / simplify plan administration].
+
+Assets transferred in the merger:
+
+| | Amount |
+|---|--------|
+| Investments at fair value | $X |
+| Participant loans | X |
+| Receivables | X |
+| Forfeitures | X |
+| **Total assets merged** | **$X** |
+
+The merger included [NUMBER] participant accounts. Participants from the merged plan retained full vesting credit for service with [PRIOR EMPLOYER] and investment elections were mapped to comparable funds in the Plan.
+
+---
+
+### Note: Plan Spinoff
+
+Effective [DATE], the Plan transferred assets to the newly established [SPUN-OFF PLAN NAME] in connection with [describe corporate transaction].
+
+| | Amount |
+|---|--------|
+| Participant account balances | $X |
+| Participant loans | X |
+| **Total spun off** | **$X** |
+
+The spinoff included [NUMBER] participant accounts related to employees of [ENTITY NAME].
+
+---
+
+### Note: Plan Conversion
+
+*Traditional to Safe Harbor:*
+Effective [DATE], the Plan was amended to convert from a traditional 401(k) plan to a Safe Harbor 401(k) plan. The Company now provides a Safe Harbor matching contribution equal to [describe formula]. As a result of the conversion, the Plan is no longer required to perform ADP/ACP nondiscrimination testing.
+
+*Safe Harbor to Traditional:*
+Effective [DATE], the Plan was amended to convert from a Safe Harbor 401(k) plan to a traditional 401(k) plan. The Plan is now subject to ADP/ACP nondiscrimination testing. The Company provides a discretionary matching contribution as described in Note 1.
+
+*Conversion to Roth In-Plan:*
+Effective [DATE], the Plan was amended to permit in-plan Roth conversions. Participants may elect to convert all or a portion of their pre-tax account balance to a designated Roth account within the Plan. During the plan year, $[AMOUNT] was converted from pre-tax to Roth accounts.
+
+---
+
+### Note: Plan Amendment
+
+The Plan was amended effective [DATE] to [describe amendment]. The amendment [had no effect on / resulted in changes to] [describe impact on participants or Plan operations].
+
+*Common amendments:*
+- Increase employer matching contribution formula
+- Add Roth contribution feature
+- Add automatic enrollment
+- Change vesting schedule (prospectively)
+- Add/remove investment options
+- Modify loan provisions
+- Add hardship withdrawal provisions
+- Comply with SECURE 2.0 requirements
+
+---
+
+### Note: Plan Termination (In Progress)
+
+On [DATE], the Company's Board of Directors approved the termination of the Plan. The Plan termination is expected to be completed during [YEAR]. Upon Plan termination, all participants will become 100% vested in their account balances. Distributions to participants are expected to commence following receipt of a favorable determination letter from the IRS and completion of all required compliance reviews.
+
+As of [DATE], the Plan termination process is ongoing and participant accounts remain invested pending final distribution.
+
+---
+
+### Note: Plan Termination (Completed)
+
+The Plan was terminated effective [DATE] pursuant to action by the Company's Board of Directors. All participants became 100% vested in their account balances upon termination. The Plan received a favorable determination letter from the IRS dated [DATE].
+
+As of [DATE], substantially all participant account balances have been distributed. Remaining assets of $[AMOUNT] relate to [missing participants / pending distributions / administrative expenses].
+
+---
+
+## Part 4: Participant Activity
+
+### Note: Notes Receivable from Participants (Loans)
+
+Notes receivable from participants represent loans made to Plan participants in accordance with Plan provisions and Department of Labor regulations. Loans are limited to the lesser of $50,000 (reduced by the highest outstanding loan balance in the preceding 12 months) or 50% of the participant's vested account balance.
+
+Loans bear interest at rates ranging from [X]% to [Y]%, which represented [prime rate plus 1%] at the time of loan origination. Principal and interest are repaid through payroll deductions over a maximum period of [5] years, or up to [15/20/25] years for the purchase of a primary residence.
+
+As of [DATE], notes receivable from participants totaled $[AMOUNT], with maturity dates ranging from [DATE] to [DATE].
+
+Loans are considered in default if repayment is not made within [90] days of the scheduled payment date. Defaulted loans are treated as deemed distributions to participants.
+
+---
+
+### Note: Forfeitures
+
+Forfeited balances of terminated participants' non-vested accounts are used to [reduce employer contributions / pay Plan administrative expenses / reallocate to remaining participants' accounts].
+
+| | [CURRENT YEAR] | [PRIOR YEAR] |
+|---|---------------|--------------|
+| Forfeitures, beginning of year | $X | $X |
+| Additions from terminated participants | X | X |
+| Amounts used to reduce employer contributions | (X) | (X) |
+| Amounts used to pay administrative expenses | (X) | (X) |
+| **Forfeitures, end of year** | **$X** | **$X** |
+
+---
+
+### Note: Excess Contributions Returned
+
+During the plan year ended [DATE], the Plan returned $[AMOUNT] of excess contributions and allocable earnings to highly compensated employees to comply with IRC Section 401(k) nondiscrimination requirements.
+
+*Alternative - Excess aggregate contributions:*
+During the plan year ended [DATE], the Plan returned $[AMOUNT] of excess aggregate contributions and allocable earnings to highly compensated employees to comply with IRC Section 401(m) nondiscrimination requirements.
+
+---
+
+### Note: Required Minimum Distributions
+
+Participants who have attained age [73] and terminated employment, or owner-employees who have attained age [73] regardless of employment status, are required to receive minimum distributions from the Plan in accordance with IRC Section 401(a)(9). The Plan calculates and processes required minimum distributions annually.
+
+---
+
+### Note: Hardship Withdrawals
+
+The Plan permits hardship withdrawals for participants who have an immediate and heavy financial need as defined by the Plan document and IRS regulations. During the plan year ended [DATE], hardship withdrawals totaled $[AMOUNT].
+
+---
+
+### Note: Qualified Domestic Relations Orders (QDROs)
+
+The Plan has established procedures for administering qualified domestic relations orders ("QDROs") in accordance with ERISA Section 206(d). During the plan year ended [DATE], the Plan processed [NUMBER] QDROs totaling $[AMOUNT] in distributions to alternate payees.
+
+---
+
+## Part 5: Compliance & Regulatory
+
+### Note: Late Remittance of Participant Contributions
+
+During the plan year ended [DATE], the Company remitted certain participant contributions to the Plan after the time frame specified by Department of Labor regulations. The Company has determined lost earnings of $[AMOUNT] and has remitted such amounts to the affected participant accounts. [The Company has filed/intends to file the appropriate correction under the DOL's Voluntary Fiduciary Correction Program.]
+
+---
+
+### Note: Prohibited Transactions
+
+*Corrected prohibited transaction:*
+During the plan year, a prohibited transaction occurred when [describe transaction]. The transaction was corrected on [DATE] by [describe correction]. Lost earnings of $[AMOUNT] were credited to affected participant accounts. [The Company filed a voluntary correction with the Department of Labor / The transaction qualified for a statutory or administrative exemption.]
+
+*Uncorrected prohibited transaction:*
+The Plan has identified a prohibited transaction that occurred during [YEAR] involving [describe transaction]. Management is currently evaluating the appropriate correction method under the Department of Labor's Voluntary Fiduciary Correction Program. The potential lost earnings related to this transaction are estimated to be $[AMOUNT].
+
+---
+
+### Note: Partial Plan Termination
+
+During the plan year ended [DATE], the Company [experienced a significant reduction in workforce / closed a facility / discontinued a division], resulting in the termination of approximately [XX]% of Plan participants. The Plan administrator has determined that a partial plan termination [occurred / may have occurred] under IRC Section 411(d)(3). As a result, all affected participants became 100% vested in their employer contribution accounts.
+
+---
+
+### Note: Fidelity Bond
+
+As required by ERISA Section 412, the Plan is covered by a fidelity bond of $[AMOUNT] to protect against losses from fraud or dishonesty by Plan fiduciaries and persons who handle Plan funds.
+
+---
+
+### Note: Reconciliation to Form 5500
+
+The following is a reconciliation of net assets available for benefits per the financial statements to the Form 5500 Annual Return/Report:
+
+| | [DATE] |
+|---|--------|
+| Net assets available for benefits per the financial statements | $X |
+| Adjustment from contract value to fair value for fully benefit-responsive investment contracts | X |
+| **Net assets available for benefits per the Form 5500** | **$X** |
+
+The following is a reconciliation of benefits paid to participants per the financial statements to the Form 5500:
+
+| | [DATE] |
+|---|--------|
+| Benefits paid to participants per the financial statements | $X |
+| Add: Amounts payable at end of year | X |
+| Less: Amounts payable at beginning of year | (X) |
+| **Benefits paid to participants per the Form 5500** | **$X** |
+
+---
+
+## Part 6: Special Situations
+
+### Note: Litigation
+
+*No litigation:*
+The Plan is not aware of any pending or threatened litigation against the Plan that would have a material adverse effect on the Plan's financial statements.
+
+*Pending litigation:*
+The Plan is subject to legal proceedings and claims in the ordinary course of business. Management believes, based on current information and consultation with legal counsel, that the ultimate resolution of these matters will not have a material adverse effect on the Plan's financial statements.
+
+*Significant litigation:*
+The Plan is named as a defendant in [describe litigation]. The lawsuit alleges [describe allegations]. Management is vigorously defending against these claims. At this time, management is unable to predict the outcome or estimate the potential loss, if any, related to this matter. [Alternatively: Management has estimated a range of potential loss of $X to $Y and has recorded a liability of $X based on the most likely outcome.]
+
+---
+
+### Note: Cybersecurity Incident
+
+During the plan year, [the Plan / the Plan's recordkeeper / the Plan's service provider] experienced a cybersecurity incident involving [describe nature of incident]. The incident affected [describe impact - number of participants, type of data, etc.].
+
+[The Plan / The service provider] has taken the following actions in response:
+- [Notification of affected participants]
+- [Credit monitoring services offered]
+- [Enhanced security measures implemented]
+- [Regulatory notifications filed]
+
+As of [DATE], [no Plan assets were lost as a result of the incident / $X of Plan assets were lost and are being pursued for recovery / the full extent of the impact is still being assessed]. [Insurance coverage / Indemnification provisions] are expected to cover [all/a portion of] any losses.
+
+---
+
+### Note: Missing Participants
+
+The Plan has been unable to locate [NUMBER] participants with account balances totaling $[AMOUNT] as of [DATE]. The Plan administrator has conducted searches in accordance with Department of Labor guidance, including [describe search methods - certified mail, commercial locator services, etc.].
+
+Unclaimed accounts are maintained in the Plan pending location of the missing participants. Accounts may be subject to state unclaimed property laws if participants cannot be located.
+
+---
+
+### Note: Subsequent Events
+
+*Plan evaluated subsequent events:*
+The Plan has evaluated subsequent events through [REPORT DATE], the date the financial statements were available to be issued.
+
+*Material subsequent event - recognized:*
+Subsequent to year-end, on [DATE], [describe event]. The effect of this event has been recognized in the accompanying financial statements.
+
+*Material subsequent event - not recognized:*
+Subsequent to year-end, on [DATE], [describe event]. The effect of this event has not been recognized in the accompanying financial statements but requires disclosure. [Examples: market decline, plan amendment, plan termination, corporate transaction, significant distribution]
+
+*Examples:*
+- On [DATE], the Company announced it would be acquired by [ACQUIRING COMPANY]. The transaction is expected to close in [TIMEFRAME], at which point the Plan may be merged with the acquirer's plan.
+- Subsequent to year-end, global financial markets experienced significant volatility resulting in a decline in the fair value of Plan investments. As of [DATE], net assets available for benefits had decreased by approximately $[AMOUNT] or [X]% from year-end.
+- On [DATE], the Plan was amended to [describe amendment], effective [DATE].
+
+---
+
+### Note: Plan Frozen
+
+Effective [DATE], the Plan was frozen and no longer accepts new participants or contributions. Existing participant accounts continue to share in investment earnings and participants may continue to make permitted withdrawals and transfers. The Company has not expressed any intent to terminate the Plan at this time.
+
+---
+
+### Note: Change in Recordkeeper
+
+Effective [DATE], the Plan changed its recordkeeper from [OLD RECORDKEEPER] to [NEW RECORDKEEPER]. In connection with the transition, the Plan experienced a blackout period from [START DATE] to [END DATE] during which participants were unable to [describe restricted activities - change investment elections, obtain loans, request distributions, etc.]. Participants were notified of the blackout period in accordance with Department of Labor regulations.
+
+---
+
+### Note: COVID-19 Related Distributions and Loans (Legacy)
+
+*For plan years that included CARES Act provisions:*
+The Coronavirus Aid, Relief, and Economic Security Act ("CARES Act") provided for special distributions and loan provisions during 2020. During the plan year, the Plan processed $[AMOUNT] of coronavirus-related distributions to [NUMBER] participants. [Additionally, the Plan suspended loan repayments for $[AMOUNT] of participant loans in accordance with the CARES Act provisions.]
+
+---
+
+## Part 7: SECURE 2.0 Disclosures
+
+### Note: Automatic Enrollment Feature
+
+Effective [DATE], the Plan implemented an automatic enrollment feature in accordance with ERISA Section 514(e) [and SECURE 2.0 Act requirements for new plans]. Eligible employees are automatically enrolled in the Plan at a deferral rate of [X]% of compensation unless they elect otherwise. The automatic deferral rate increases by [1]% annually until reaching [10/15]%. Automatically enrolled participants are invested in the Plan's qualified default investment alternative, the [QDIA FUND NAME], unless they elect otherwise.
+
+Participants may elect to opt out of automatic enrollment or change their deferral rate at any time.
+
+---
+
+### Note: Enhanced Catch-Up Contributions (Ages 60-63)
+
+Effective for the 2025 plan year, the Plan allows participants who attain ages 60, 61, 62, or 63 during the calendar year to make enhanced catch-up contributions up to the greater of $10,000 or 150% of the regular catch-up limit (indexed for inflation). For 2025, this enhanced limit is $[11,250].
+
+---
+
+### Note: Long-Term Part-Time Employees
+
+Effective for the [2024/2025] plan year, the Plan provides eligibility for long-term part-time employees in accordance with [SECURE Act / SECURE 2.0 Act] requirements. Employees who complete at least [500] hours of service in [three consecutive / two consecutive] 12-month periods are eligible to make elective deferrals to the Plan. Long-term part-time employees are not eligible for employer contributions until they meet the Plan's standard eligibility requirements.
+
+---
+
+### Note: Student Loan Matching Contributions
+
+Effective [DATE], the Plan permits the Company to make matching contributions based on qualified student loan payments made by participants, in accordance with SECURE 2.0 Act Section 110. Participants who make qualified student loan payments may receive matching contributions as if they had made elective deferrals equal to their student loan payments, subject to the Plan's matching formula and applicable limits.
+
+During the plan year ended [DATE], the Company made $[AMOUNT] in student loan matching contributions to [NUMBER] participants.
+
+---
+
+### Note: Pension-Linked Emergency Savings Account (PLESA)
+
+Effective [DATE], the Plan established a pension-linked emergency savings account feature in accordance with SECURE 2.0 Act Section 127. Non-highly compensated employees may contribute to a PLESA, which is a designated Roth account within the Plan. Contributions are limited to $[2,500] and participants may make withdrawals at least once per calendar month without penalty.
+
+As of [DATE], [NUMBER] participants had PLESA accounts with a total balance of $[AMOUNT].
+
+---
+
+### Note: Roth Employer Contributions
+
+Effective [DATE], the Plan was amended to permit participants to designate employer matching and/or nonelective contributions as Roth contributions, in accordance with SECURE 2.0 Act Section 604. Participants who elect this option will include the designated Roth employer contributions in their gross income for the year of contribution.
+
+---
+
+### Note: Self-Certification for Hardship Withdrawals
+
+The Plan permits participants to self-certify that they have a financial hardship and have no other reasonably available resources to meet the hardship, in accordance with IRS regulations and SECURE 2.0 Act provisions. The Plan administrator relies on these self-certifications unless the administrator has actual knowledge to the contrary.
+
+---
+
+## Part 8: Form 5500 Reconciliation
+
+### Note: Reconciliation of Financial Statements to Form 5500
+
+The following is a reconciliation of net assets available for benefits per the financial statements to the Form 5500:
+
+| | December 31, [YEAR] | December 31, [PRIOR YEAR] |
+|---|---------------------|--------------------------|
+| Net assets available for benefits per the financial statements | $X | $X |
+| Adjustment from contract value to fair value for fully benefit-responsive investment contracts | X | X |
+| **Net assets available for benefits per the Form 5500** | **$X** | **$X** |
+
+The following is a reconciliation of investment income per the financial statements to the Form 5500:
+
+| | Year Ended December 31, [YEAR] |
+|---|------------------------------|
+| Net investment income per the financial statements | $X |
+| Adjustment from contract value to fair value for fully benefit-responsive investment contracts | X |
+| **Net investment income per the Form 5500** | **$X** |
+
+The following is a reconciliation of benefits paid to participants per the financial statements to the Form 5500:
+
+| | Year Ended December 31, [YEAR] |
+|---|------------------------------|
+| Benefits paid to participants per the financial statements | $X |
+| Add: Amounts payable at end of year | X |
+| Less: Amounts payable at beginning of year | (X) |
+| Deemed distributions of participant loans | X |
+| **Benefits paid to participants per the Form 5500** | **$X** |
+
+The following is a reconciliation of contributions per the financial statements to the Form 5500:
+
+| | Year Ended December 31, [YEAR] |
+|---|------------------------------|
+| Employer contributions per the financial statements | $X |
+| Add: Employer contributions receivable at end of year | X |
+| Less: Employer contributions receivable at beginning of year | (X) |
+| **Employer contributions per the Form 5500** | **$X** |
+
+| | Year Ended December 31, [YEAR] |
+|---|------------------------------|
+| Participant contributions per the financial statements | $X |
+| Add: Participant contributions receivable at end of year | X |
+| Less: Participant contributions receivable at beginning of year | (X) |
+| **Participant contributions per the Form 5500** | **$X** |
+
+---
+
+## Appendix: Quick Reference by Scenario
+
+### Which Footnotes to Include
+
+| Scenario | Required Notes |
+|----------|---------------|
+| **All Plans** | Plan Description, Accounting Policies, Tax Status, Fair Value, Related Parties, Plan Termination Rights, Risks |
+| **Has Stable Value Fund** | Fully Benefit-Responsive Contracts |
+| **Has Employer Stock** | Employer Securities, Concentration Risk |
+| **Has Participant Loans** | Notes Receivable from Participants |
+| **Plan Merger (Assets In)** | Transfers from Other Plans |
+| **Plan Spinoff (Assets Out)** | Transfers to Other Plans |
+| **Joining a PEP** | Transfer to PEP |
+| **Leaving a PEP** | Transfer from PEP |
+| **Joining a MEP** | Transfer to MEP |
+| **Leaving a MEP** | Transfer from MEP |
+| **Late Contributions** | Late Remittance |
+| **Excess Contributions Returned** | Excess Contributions |
+| **Partial Termination** | Partial Plan Termination |
+| **Terminated Plan** | Plan Termination |
+| **Frozen Plan** | Plan Frozen |
+| **SECURE 2.0 Features** | Applicable SECURE 2.0 notes |
+| **Changed Recordkeepers** | Change in Recordkeeper |
+| **All Plans** | Form 5500 Reconciliation |
+
+---
+
+*Last Updated: November 2025*
+*For 2025 Plan Year Financial Statements (Audits Performed in 2026)*


### PR DESCRIPTION
- Add 401k-footnote-disclosures.md (~750 lines) with every footnote scenario
- Standard required disclosures (plan description, accounting policies, tax status, fair value)
- Investment disclosures (stable value, employer securities, self-directed brokerage, alternatives)
- Transfer disclosures (to/from PEP, to/from MEP, mergers, spinoffs, conversions)
- Participant activity (loans, forfeitures, excess contributions, RMDs, hardships, QDROs)
- Compliance disclosures (late contributions, prohibited transactions, partial termination)
- Special situations (litigation, cybersecurity, missing participants, subsequent events)
- SECURE 2.0 disclosures (auto-enrollment, enhanced catch-up, LTPT, student loan match, PLESA)
- Form 5500 reconciliation templates
- Quick reference table for which footnotes to include by scenario
- Update README to v2.2.0 with 48+ documents, 37,000+ lines